### PR TITLE
Add RUN go mod init

### DIFF
--- a/solutions/go-helloworld/Dockerfile
+++ b/solutions/go-helloworld/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /go/src/app
 
 ADD . .
 
+RUN go mod init
+
 RUN go build  -o helloworld
 
 EXPOSE 6111


### PR DESCRIPTION
So many scholars are encountering "executor failed running" error because "RUN go mod init" is missing in the Dockerfile. So I think it should be added. Issue #29 