### PR TITLE
Added a fix for "go.mod file not found" error

### DIFF
--- a/solutions/go-helloworld/Dockerfile
+++ b/solutions/go-helloworld/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /go/src/app
 
 ADD . .
 
+# If this error comes: "go: go.mod file not found in current directory or any parent directory; see 'go help modules'", then uncomment the below line.
+#RUN go mod init
+
 RUN go build  -o helloworld
 
 EXPOSE 6111


### PR DESCRIPTION
In many cases, due to some issues related to the go version, it gives error "go: go.mod file not found in current directory or any parent directory; see 'go help modules'", while running the docker build command. To solve this, I have added a small fix, which initializes the go module and the container is built successfully.