### PR TITLE
Update Dockerfile

### DIFF
--- a/solutions/go-helloworld/Dockerfile
+++ b/solutions/go-helloworld/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /go/src/app
 
 ADD . .
 
+RUN go env -w GO111MODULE=auto
 RUN go build  -o helloworld
 
 EXPOSE 6111


### PR DESCRIPTION
The go command now builds packages in module-aware mode by default, even when no go.mod is present.