### PR TITLE
Fix project Vagrantfile: bump to Leap 15.6 and repair provision command

### DIFF
--- a/project/Vagrantfile
+++ b/project/Vagrantfile
@@ -5,12 +5,12 @@ ENV["TERM"]="linux"
 Vagrant.require_version ">= 2.2.10"
 Vagrant.configure("2") do |config|
   config.vm.provision "shell",
-    inline: "sudo su - && zypper update && zypper install -y apparmor-parser"
+    inline: "sudo zypper update -y && sudo zypper install -y apparmor-parser"
   
   # Set the image for the vagrant box
-  config.vm.box = "opensuse/Leap-15.2.x86_64"
+  config.vm.box = "opensuse/Leap-15.6.x86_64"
   # Set the image version
-  config.vm.box_version = "15.2.31.632"
+  config.vm.box_version = "15.6.13.356"
 
   # Forward the ports from the guest VM to the local host machine
   # Forward more ports, as needed


### PR DESCRIPTION
## Summary
- `project/Vagrantfile` targeted openSUSE Leap 15.2, which reached EOL in Jan 2022 — its repos are gone, so `zypper update` fails inside the box. Bumped to `opensuse/Leap-15.6.x86_64` (`15.6.13.356`), matching `exercises/Vagrantfile`.
- The provision line was `sudo su - && zypper update && zypper install -y apparmor-parser`. `sudo su -` opens an interactive login shell, so the `&&` chain after it never runs. Replaced with `sudo zypper update -y && sudo zypper install -y apparmor-parser`.

## Test plan
- [ ] `vagrant up` from `project/` on a Windows + VirtualBox 7.0.x host with Vagrant 2.4.9
- [ ] Confirm the box downloads and the provision step installs `apparmor-parser` without prompting
- [ ] If `15.6.13.356` is no longer published, drop the `config.vm.box_version` line to pull the latest