### PR TITLE
Fix nginx-alpine Service targetPort (8111 -> 80)

### DIFF
--- a/exercises/manifests/service.yaml
+++ b/exercises/manifests/service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
   - port: 8111
     protocol: TCP
-    targetPort: 8111
+    targetPort: 80
   selector:
     app: nginx
     tag: alpine


### PR DESCRIPTION
## Summary
`exercises/manifests/service.yaml` sets `targetPort: 8111` on the `nginx-alpine` Service, but the corresponding Deployment runs the stock `nginx:alpine` image with no `containerPort` override and no custom nginx config. The container actually listens on **port 80**, so requests to the Service got connection refused — nothing on the pod was bound to 8111.

This PR sets `targetPort: 80` so the Service forwards traffic to the port nginx is actually listening on. The cluster-facing `port` stays at `8111` to keep the existing course material consistent (clients still hit `nginx-alpine:8111`).

Fixes #94

## Test plan
- [ ] `kubectl apply -f exercises/manifests/` brings up the namespace, deployment, configmap, and service cleanly.
- [ ] `kubectl -n demo get endpoints nginx-alpine` lists 3 endpoints, each on `:80` (matching the 3 nginx pods).
- [ ] From inside the cluster, `curl http://nginx-alpine.demo:8111` returns the default nginx welcome page (was previously connection refused).
- [ ] `kubectl -n demo port-forward svc/nginx-alpine 8111:8111` followed by `curl http://localhost:8111` returns the nginx welcome page from the host.